### PR TITLE
Migrate from simple list to filtering list

### DIFF
--- a/src/Midas-Core/MiBusLogsList.class.st
+++ b/src/Midas-Core/MiBusLogsList.class.st
@@ -2,10 +2,10 @@ Class {
 	#name : #MiBusLogsList,
 	#superclass : #SpPresenter,
 	#instVars : [
-		'logsList',
 		'bus',
 		'busName',
-		'clearButton'
+		'clearButton',
+		'logsFilteringList'
 	],
 	#category : #'Midas-Core-Logger'
 }
@@ -23,15 +23,15 @@ MiBusLogsList class >> buildCommandsGroupWith: presenterInstance forRoot: rootCo
 
 { #category : #specs }
 MiBusLogsList class >> defaultSpec [
+
 	^ SpBoxLayout newVertical
-		add:
-			(SpBoxLayout newHorizontal
-				add: #busName;
-				add: #clearButton width: self buttonWidth;
-				yourself)
-			height: self toolbarHeight;
-		add: #logsList;
-		yourself
+		  add: (SpBoxLayout newHorizontal
+				   add: #busName;
+				   add: #clearButton width: self buttonWidth;
+				   yourself)
+		  height: self toolbarHeight;
+		  add: #logsFilteringList;
+		  yourself
 ]
 
 { #category : #accessing }
@@ -49,7 +49,7 @@ MiBusLogsList >> forBus: aBus [
 
 	bus := aBus.
 	busName label: 'Bus: ' , bus name.
-	logsList items: bus logger logs
+	logsFilteringList items: bus logger logs
 ]
 
 { #category : #initialization }
@@ -65,10 +65,10 @@ MiBusLogsList >> initializeClearButton [
 { #category : #initialization }
 MiBusLogsList >> initializeLogsList [
 
-	logsList := self newFilteringList
+	logsFilteringList := self newFilteringList
 		            display: [ :log | log entity mooseName ];
 		            yourself.
-	logsList listPresenter
+	logsFilteringList listPresenter
 		contextMenu: [ self rootCommandsGroup asMenuPresenter ];
 		whenSelectionChangedDo: [ :selection | 
 			selection selectedItem ifNotNil: [ 
@@ -92,7 +92,7 @@ MiBusLogsList >> logger [
 { #category : #accessing }
 MiBusLogsList >> miSelectedItem [
 
-	^ logsList listPresenter selectedItems
+	^ logsFilteringList listPresenter selectedItems
 		  ifEmpty: [  ]
 		  ifNotEmpty: [ :list | list anyOne entity ]
 ]
@@ -100,7 +100,7 @@ MiBusLogsList >> miSelectedItem [
 { #category : #accessing }
 MiBusLogsList >> miSelectedLog [
 
-	^ logsList selectedItem
+	^ logsFilteringList selectedItem
 ]
 
 { #category : #actions }

--- a/src/Midas-Core/MiBusLogsList.class.st
+++ b/src/Midas-Core/MiBusLogsList.class.st
@@ -46,6 +46,7 @@ MiBusLogsList >> cleanLogger [
 
 { #category : #actions }
 MiBusLogsList >> forBus: aBus [
+
 	bus := aBus.
 	busName label: 'Bus: ' , bus name.
 	logsList items: bus logger logs
@@ -63,13 +64,15 @@ MiBusLogsList >> initializeClearButton [
 
 { #category : #initialization }
 MiBusLogsList >> initializeLogsList [
-	logsList := self newList
-		display: [ :log | log entity mooseName ];
+
+	logsList := self newFilteringList
+		            display: [ :log | log entity mooseName ];
+		            yourself.
+	logsList listPresenter
 		contextMenu: [ self rootCommandsGroup asMenuPresenter ];
 		whenSelectionChangedDo: [ :selection | 
-			selection selectedItem
-				ifNotNil: [ self setOwnerSelectedItem: selection selectedItem ] ];
-		yourself
+			selection selectedItem ifNotNil: [ 
+					self setOwnerSelectedItem: selection selectedItem ] ]
 ]
 
 { #category : #initialization }
@@ -88,14 +91,16 @@ MiBusLogsList >> logger [
 
 { #category : #accessing }
 MiBusLogsList >> miSelectedItem [
-	^ logsList selectedItems
-		ifEmpty: [  ]
-		ifNotEmpty: [ :list | list anyOne entity ]
+
+	^ logsList listPresenter selectedItems
+		  ifEmpty: [  ]
+		  ifNotEmpty: [ :list | list anyOne entity ]
 ]
 
 { #category : #accessing }
 MiBusLogsList >> miSelectedLog [
-	^ logsList selection selectedItem
+
+	^ logsList selectedItem
 ]
 
 { #category : #actions }

--- a/src/Midas-Meta/MiModelRootBrowser.class.st
+++ b/src/Midas-Meta/MiModelRootBrowser.class.st
@@ -94,8 +94,9 @@ MiModelRootBrowser >> followAction [
 MiModelRootBrowser >> initializeList [
 
 	modelFilteringList := self newFilteringList
-		                  items: MooseModel root;
-		                  display: [ :mooseModel | mooseModel name ].
+		                      items: MooseModel root;
+		                      display: [ :mooseModel | mooseModel name ];
+		                      yourself.
 	modelFilteringList listPresenter
 		contextMenu: [ self rootCommandsGroup asMenuPresenter ];
 		whenSelectionChangedDo: [ :selected | 

--- a/src/Midas-Meta/MiModelRootBrowser.class.st
+++ b/src/Midas-Meta/MiModelRootBrowser.class.st
@@ -12,8 +12,8 @@ Class {
 	#name : #MiModelRootBrowser,
 	#superclass : #MiAbstractBrowser,
 	#instVars : [
-		'modelPresenter',
-		'toolbar'
+		'toolbar',
+		'modelFilteringList'
 	],
 	#category : #'Midas-Meta-ModelRootBrowser'
 }
@@ -30,10 +30,13 @@ MiModelRootBrowser class >> buildCommandsGroupWith: presenterInstance forRoot: r
 
 { #category : #specs }
 MiModelRootBrowser class >> defaultSpec [
+
 	^ super defaultSpec
-		add: #toolbar withConstraints: [ :constraints | constraints height: self toolbarHeight ];
-		add: #modelPresenter;
-		yourself
+		  add: #toolbar
+		  withConstraints: [ :constraints | 
+			  constraints height: self toolbarHeight ];
+		  add: #modelFilteringList;
+		  yourself
 ]
 
 { #category : #specs }
@@ -89,15 +92,17 @@ MiModelRootBrowser >> followAction [
 
 { #category : #initialization }
 MiModelRootBrowser >> initializeList [
-	modelPresenter := self newList
-		items: MooseModel root;
-		display: [ :mooseModel | mooseModel name ];
+
+	modelFilteringList := self newFilteringList
+		                  items: MooseModel root;
+		                  display: [ :mooseModel | mooseModel name ].
+	modelFilteringList listPresenter
 		contextMenu: [ self rootCommandsGroup asMenuPresenter ];
 		whenSelectionChangedDo: [ :selected | 
 			model selected: selected selectedItem.
-			self isFreeze
-				ifFalse:
-					[ self buses do: [ :bus | bus globallySelect: selected selectedItem ] ] ]
+			self isFreeze ifFalse: [ 
+					self buses do: [ :bus | 
+							bus globallySelect: selected selectedItem ] ] ]
 ]
 
 { #category : #initialization }
@@ -117,12 +122,8 @@ MiModelRootBrowser >> initializeToolbar [
 
 { #category : #accessing }
 MiModelRootBrowser >> miSelectedItem [
-	^ modelPresenter selection selectedItem
-]
 
-{ #category : #accessing }
-MiModelRootBrowser >> modelPresenter [
-	^ modelPresenter
+	^ modelFilteringList selectedItem
 ]
 
 { #category : #initialization }
@@ -131,7 +132,7 @@ MiModelRootBrowser >> refreshToolbarButton [
 	^ SpToolbarButtonPresenter new
 		  icon: (self iconNamed: #smallUpdate);
 		  help: 'Refresh list';
-		  action: [ modelPresenter updateList ];
+		  action: [ modelFilteringList listPresenter updateList ];
 		  yourself
 ]
 
@@ -142,21 +143,23 @@ MiModelRootBrowser >> selected [
 
 { #category : #accessing }
 MiModelRootBrowser >> selectedObject [
-	^ modelPresenter selection selectedItem
+
+	^ modelFilteringList selectedItem
 ]
 
 { #category : #updating }
 MiModelRootBrowser >> updateForNewModel: aModel [
 
 	self class updateAll.
-	modelPresenter selectItem: aModel
+	modelFilteringList selectItem: aModel
 ]
 
 { #category : #updating }
 MiModelRootBrowser >> updateList [
-	self
-		freezeDuring: [ | selected |
-			selected := self selected.
-			modelPresenter updateList.
-			modelPresenter selectItem: selected ]
+
+	self freezeDuring: [ 
+		| selected |
+		selected := self selected.
+		modelFilteringList listPresenter updateList.
+		modelFilteringList selectItem: selected ]
 ]

--- a/src/Midas-Tagging/MiTagDetailPage.class.st
+++ b/src/Midas-Tagging/MiTagDetailPage.class.st
@@ -6,13 +6,13 @@ Class {
 	#superclass : #MiPresenter,
 	#instVars : [
 		'tagModel',
-		'tagEntitiesList',
-		'incomingEntitiesList',
 		'btnAdd',
 		'btnAddAll',
 		'btnDel',
 		'btnDelAll',
-		'lblTagEntities'
+		'lblTagEntities',
+		'tagEntitiesFilteringList',
+		'incomingEntitiesFilteringList'
 	],
 	#category : #'Midas-Tagging'
 }
@@ -37,21 +37,22 @@ MiTagDetailPage class >> filler [
 
 { #category : #specs }
 MiTagDetailPage class >> mainContentLayout [
-	^SpBoxLayout newHorizontal
-		add: #incomingEntitiesList;
-		add: (SpBoxLayout newVertical
-			spacing: 5 ;
-			add: self filler expand: true;
-			add: #btnAdd expand: false;
-			add: #btnAddAll expand: false;
-			add: #btnDel expand: false;
-			add: #btnDelAll expand: false;
-			add: self filler expand: true;
-			yourself)
-		withConstraints: [ :constraints | constraints width: self middleColumnWidth ];
 
-		add: #tagEntitiesList;
-		yourself
+	^ SpBoxLayout newHorizontal
+		  add: #incomingEntitiesFilteringList;
+		  add: (SpBoxLayout newVertical
+				   spacing: 5;
+				   add: self filler expand: true;
+				   add: #btnAdd expand: false;
+				   add: #btnAddAll expand: false;
+				   add: #btnDel expand: false;
+				   add: #btnDelAll expand: false;
+				   add: self filler expand: true;
+				   yourself)
+		  withConstraints: [ :constraints | 
+		  constraints width: self middleColumnWidth ];
+		  add: #tagEntitiesFilteringList;
+		  yourself
 ]
 
 { #category : #specs }
@@ -61,28 +62,28 @@ MiTagDetailPage class >> middleColumnWidth [
 
 { #category : #action }
 MiTagDetailPage >> add [
-	incomingEntitiesList selectedItem
+	incomingEntitiesFilteringList selectedItem
 		ifNotNil: [ :entity | tagModel tagEntity: entity ].
 	self refreshTagEntitiesList
 ]
 
 { #category : #action }
 MiTagDetailPage >> addAll [
-	incomingEntitiesList items
+	incomingEntitiesFilteringList items
 		do: [ :entity | tagModel tagEntity: entity ].
 	self refreshTagEntitiesList
 ]
 
 { #category : #action }
 MiTagDetailPage >> del [
-	tagEntitiesList selectedItem
+	tagEntitiesFilteringList selectedItem
 		ifNotNil: [ :entity | tagModel untagEntity: entity ].
 	self refreshTagEntitiesList
 ]
 
 { #category : #action }
 MiTagDetailPage >> delAll [
-	tagEntitiesList items
+	tagEntitiesFilteringList items
 		do: [ :entity | tagModel untagEntity: entity ].
 	self refreshTagEntitiesList
 ]
@@ -97,33 +98,32 @@ MiTagDetailPage >> ideEntities [
 
 { #category : #initialization }
 MiTagDetailPage >> initializePresenters [
+
 	super initializePresenters.
 
-	lblTagEntities := self newLabel
-		label: 'Entities in tag:'.
+	lblTagEntities := self newLabel label: 'Entities in tag:'.
 
-	incomingEntitiesList := self newList
-		display: [ :entity | entity name ] ;
-		yourself.
+	incomingEntitiesFilteringList := self newFilteringList
+		                                 display: [ :entity | entity name ];
+		                                 yourself.
 	self refreshIdeEntitiesList.
-	tagEntitiesList := self newList
-		display: [ :entity | entity name ] ;
-		yourself.
+	tagEntitiesFilteringList := self newFilteringList
+		                            display: [ :entity | entity name ];
+		                            yourself.
 	self refreshTagEntitiesList.
 
 	btnAdd := self newButton
-		label: ' > ' ;
-		action: [ self add ].
+		          label: ' > ';
+		          action: [ self add ].
 	btnAddAll := self newButton
-		label: '>>>' ;
-		action: [ self addAll ].
+		             label: '>>>';
+		             action: [ self addAll ].
 	btnDel := self newButton
-		label: ' < ' ;
-		action: [ self del ].
+		          label: ' < ';
+		          action: [ self del ].
 	btnDelAll := self newButton
-		label: '<<<' ;
-		action: [ self delAll ].
-
+		             label: '<<<';
+		             action: [ self delAll ]
 ]
 
 { #category : #refreshing }
@@ -133,12 +133,12 @@ MiTagDetailPage >> onBrowserPageRedisplay [
 
 { #category : #refreshing }
 MiTagDetailPage >> refreshIdeEntitiesList [
-	incomingEntitiesList items: self ideEntities
+	incomingEntitiesFilteringList items: self ideEntities
 ]
 
 { #category : #refreshing }
 MiTagDetailPage >> refreshTagEntitiesList [
-	tagEntitiesList items: self tagEntities
+	tagEntitiesFilteringList items: self tagEntities
 ]
 
 { #category : #accessing }
@@ -153,7 +153,7 @@ MiTagDetailPage >> tagEntities [
 MiTagDetailPage >> tagModel: aModel [
 	tagModel := aModel.
 	self refreshTagEntitiesList.
-	incomingEntitiesList items: tagModel mostRecentEntity
+	incomingEntitiesFilteringList items: tagModel mostRecentEntity
 	
 
 ]


### PR DESCRIPTION
- Migrated list presenter to filtering list on MiModelRootBrowser and changed the variable name from modelPresenter to modelFilteringList. Also deleted the accessing method modelPresenter because it was never called.

- Migrated list presenter to filtering presenter on MiBusLogsList. Changed variable name from logsList to logsFilteringList. 

- Migrated list presenter to filtering list presenter on MiTagBrowserPresenter. Also changed instance variables names to filtering list