### PR TITLE
Color chooser on tag browser

### DIFF
--- a/src/Midas-Tagging/MiTagBrowser.class.st
+++ b/src/Midas-Tagging/MiTagBrowser.class.st
@@ -77,11 +77,20 @@ MiTagBrowser >> followAction [
 
 { #category : #initialization }
 MiTagBrowser >> initializePresenters [
+
 	super initializePresenters.
 	mainPresenter := self newNotebook
-		addPage: self manageTagsPage ;
-		addPage: self tagDetailsPage ;
-		yourself
+		                 addPage: self manageTagsPage;
+		                 addPage: self tagDetailsPage;
+		                 yourself
+]
+
+{ #category : #initialization }
+MiTagBrowser >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: self class title;
+		initialExtent: 500 @ 500
 ]
 
 { #category : #initialization }

--- a/src/Midas-Tagging/MiTagBrowser.class.st
+++ b/src/Midas-Tagging/MiTagBrowser.class.st
@@ -60,6 +60,12 @@ MiTagBrowser class >> title [
 	^ 'Tag browser'
 ]
 
+{ #category : #specs }
+MiTagBrowser class >> windowSize [
+
+	^ 500 @ 500
+]
+
 { #category : #testing }
 MiTagBrowser >> accept: anObject [
 	^ anObject isCollection
@@ -83,14 +89,6 @@ MiTagBrowser >> initializePresenters [
 		                 addPage: self manageTagsPage;
 		                 addPage: self tagDetailsPage;
 		                 yourself
-]
-
-{ #category : #initialization }
-MiTagBrowser >> initializeWindow: aWindowPresenter [
-
-	aWindowPresenter
-		title: self class title;
-		initialExtent: 500 @ 500
 ]
 
 { #category : #initialization }

--- a/src/Midas-Tagging/MiTagManagementPage.class.st
+++ b/src/Midas-Tagging/MiTagManagementPage.class.st
@@ -8,9 +8,9 @@ Class {
 		'tagManagmt',
 		'catManagmt',
 		'txtDescription',
-		'txtColor',
+		'rgbColorSliders',
 		'tagModel',
-		'colorExample'
+		'colorCanvas'
 	],
 	#category : #'Midas-Tagging'
 }
@@ -18,20 +18,20 @@ Class {
 { #category : #specs }
 MiTagManagementPage class >> defaultSpec [
 
-	^SpBoxLayout newVertical 
-		add: 'Category' expand: false ;
-		add: #catManagmt ;
-		add: 'Tag' expand: false ;
-		add: #tagManagmt ;
-		
-		add: (SpGridLayout new
-			add: 'Description:' at: 1 @ 1 ;
-			add: #txtDescription at: 2 @ 1 span: 2 @ 1 ;
-			add: 'Color:' at: 1 @ 2 ;
-			add: #txtColor at: 2 @ 2 ;
-			add: #colorExample at: 3 @ 2 ;
-			yourself) ;
-		yourself
+	^ SpBoxLayout newVertical
+		  add: 'Category' expand: false;
+		  add: #catManagmt;
+		  add: 'Tag' expand: false;
+		  add: #tagManagmt;
+		  add: 'Description:' expand: false;
+		  add: #txtDescription;
+		  add: 'Color:' expand: false;
+		  add: (SpPanedLayout newLeftToRight
+				   addFirst: #rgbColorSliders;
+				   addSecond: #colorCanvas;
+				   yourself)
+		  expand: true;
+		  yourself
 ]
 
 { #category : #action }
@@ -64,14 +64,11 @@ MiTagManagementPage >> initializeCategoryManagmtPart [
 
 { #category : #initialization }
 MiTagManagementPage >> initializeColorChooserPart [
-	txtColor := self newText
-		autoAccept: true;
-		color: Color white;
-		whenTextChangedDo: [ :notUsed | colorExample refresh ];
-		yourself.
+	rgbColorSliders := (self instantiate: SpRGBSliders)
+		whenChangedDo: [ :notUsed | colorCanvas refresh ].
 
-	colorExample := (self instantiate: SpRoassalPresenter)
-		script: [ :canvas | canvas color: (Color fromHexString: txtColor text asString , '000000') ];
+	colorCanvas := (self instantiate: SpRoassalPresenter)
+		script: [ :canvas | canvas color: (rgbColorSliders color) ];
 		yourself
 ]
 

--- a/src/Midas-Tagging/MiTagManagementPage.class.st
+++ b/src/Midas-Tagging/MiTagManagementPage.class.st
@@ -8,9 +8,8 @@ Class {
 		'tagManagmt',
 		'catManagmt',
 		'txtDescription',
-		'rgbColorSliders',
 		'tagModel',
-		'colorCanvas'
+		'rgbColorChooser'
 	],
 	#category : #'Midas-Tagging'
 }
@@ -26,11 +25,7 @@ MiTagManagementPage class >> defaultSpec [
 		  add: 'Description:' expand: false;
 		  add: #txtDescription;
 		  add: 'Color:' expand: false;
-		  add: (SpPanedLayout newLeftToRight
-				   addFirst: #rgbColorSliders;
-				   addSecond: #colorCanvas;
-				   yourself)
-		  expand: true;
+		  add: #rgbColorChooser;
 		  yourself
 ]
 
@@ -64,12 +59,8 @@ MiTagManagementPage >> initializeCategoryManagmtPart [
 
 { #category : #initialization }
 MiTagManagementPage >> initializeColorChooserPart [
-	rgbColorSliders := (self instantiate: SpRGBSliders)
-		whenChangedDo: [ :notUsed | colorCanvas refresh ].
 
-	colorCanvas := (self instantiate: SpRoassalPresenter)
-		script: [ :canvas | canvas color: (rgbColorSliders color) ];
-		yourself
+	rgbColorChooser := self instantiate: SpRGBChooser
 ]
 
 { #category : #initialization }

--- a/src/Midas-Tagging/SpRGBChooser.class.st
+++ b/src/Midas-Tagging/SpRGBChooser.class.st
@@ -1,0 +1,109 @@
+"
+I am a Spec widget allowing a user to choose a Color by its RGB values with the sliders, each for one of the RBG values.
+
+I manage three `SpSliderInput`.
+I set their min at 0 and their max at 255.
+I provide the method `color` that calculates a Color with the current values of the RGB sliders.
+
+_Note: The sliders are quite buggy. But this is a bug in the Spec library._
+"
+Class {
+	#name : #SpRGBChooser,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'redSlider',
+		'greenSlider',
+		'blueSlider',
+		'colorPreview'
+	],
+	#category : #'Midas-Tagging'
+}
+
+{ #category : #specs }
+SpRGBChooser class >> defaultSpec [
+
+	^ SpPanedLayout newLeftToRight
+		  add: #colorPreview;
+		  add: (SpBoxLayout newTopToBottom
+				   add: #redSlider;
+				   add: #greenSlider;
+				   add: #blueSlider;
+				   yourself);
+		  yourself
+]
+
+{ #category : #accessing }
+SpRGBChooser >> blueSlider [
+
+	^ blueSlider
+]
+
+{ #category : #accessing }
+SpRGBChooser >> color [
+
+	^ Color
+		  r: redSlider value
+		  g: greenSlider value
+		  b: blueSlider value
+		  range: 255
+]
+
+{ #category : #initialization }
+SpRGBChooser >> connectPresenters [
+
+	self whenChangedDo: [ colorPreview image: self makeRGBForm ]
+]
+
+{ #category : #accessing }
+SpRGBChooser >> greenSlider [
+
+	^ greenSlider
+]
+
+{ #category : #initialization }
+SpRGBChooser >> initializePresenters [
+
+	redSlider := self instantiate: SpSliderInput.
+	greenSlider := self instantiate: SpSliderInput.
+	blueSlider := self instantiate: SpSliderInput.
+	colorPreview := self newImage
+		                image: self makeRGBForm;
+		                yourself.
+	redSlider
+		min: 0;
+		max: 255;
+		label: 'Red'.
+	greenSlider
+		min: 0;
+		max: 255;
+		label: 'Green'.
+	blueSlider
+		min: 0;
+		max: 255;
+		label: 'Blue'.
+	self focusOrder
+		add: redSlider;
+		add: greenSlider;
+		add: blueSlider;
+		add: colorPreview
+]
+
+{ #category : #accessing }
+SpRGBChooser >> makeRGBForm [
+
+	^ (Form extent: 80 @ 80 depth: 32) fillColor: self color
+]
+
+{ #category : #accessing }
+SpRGBChooser >> redSlider [
+
+	^ redSlider
+]
+
+{ #category : #announcing }
+SpRGBChooser >> whenChangedDo: aBlock [
+
+	redSlider whenValueChangedDo: aBlock.
+	greenSlider whenValueChangedDo: aBlock.
+	blueSlider whenValueChangedDo: aBlock
+]


### PR DESCRIPTION
- I have moved the color-image-preview and the sliders into a new presenter that is called SpRGBChooser. It is located in the same Midas packages. I was thinking in modifying the spec-native presenters. But I thought that is better to create a new presenter according to our needs. Because none of the existing "rgb chooser" presenters that are already programmed in Spec do exactly what we want.

- About the bug in the slider thumb I reported it to the spec repo.