### PR TITLE
Added title and default name to the rename textEntry of MiRenameModel…

### DIFF
--- a/src/Midas-Core/MiRenameModelCommand.class.st
+++ b/src/Midas-Core/MiRenameModelCommand.class.st
@@ -21,11 +21,14 @@ MiRenameModelCommand class >> defaultName [
 
 { #category : #executing }
 MiRenameModelCommand >> execute [
+
 	| newName |
 	newName := UITheme builder
-		textEntry: 'Set new name for MooseModel ' , self model name.
-	(newName isNil or: [ newName isEmpty ])
-		ifTrue: [ ^ self ].
+		           textEntry:
+		           'Set new name for MooseModel ' , self model name
+		           title: self class defaultName
+		           entryText: self model name.
+	(newName isNil or: [ newName isEmpty ]) ifTrue: [ ^ self ].
 	self model name: newName.
 	self context update
 ]


### PR DESCRIPTION
I think that the prompt that appears when renaming a model should have more info (right click on the models browser as shown in the image)
![image](https://user-images.githubusercontent.com/33934979/115600320-1d16e580-a2cc-11eb-92e1-e71e873606fb.png)

Now the title says Entry and no text in the text input field:
![image](https://user-images.githubusercontent.com/33934979/115600916-b514cf00-a2cc-11eb-81ea-01628c1942a6.png)

It may be more helpful to have the current name and the title "Rename" as shown here:
![image](https://user-images.githubusercontent.com/33934979/115600357-24d68a00-a2cc-11eb-9ca2-0d298d6ca082.png)
