### PR TITLE
Removed Breakpoints page from MiInspectorBrowser.

### DIFF
--- a/src/Midas-Core/MiObjectInspectorPresenter.class.st
+++ b/src/Midas-Core/MiObjectInspectorPresenter.class.st
@@ -10,6 +10,16 @@ Class {
 	#category : #'Midas-Core-Inspector'
 }
 
+{ #category : #private }
+MiObjectInspectorPresenter >> allPages [
+
+	| allPagesWithoutBreakpointsPage |
+	"Remove the Breakpoints page in the inspector because is not useful in the Moose Inspector"
+	allPagesWithoutBreakpointsPage := super allPages reject: [ :aPage | 
+		                                  aPage title = 'Breakpoints' ].
+	^ allPagesWithoutBreakpointsPage
+]
+
 { #category : #'private factory' }
 MiObjectInspectorPresenter >> newInspectionForContext: aContext [
 


### PR DESCRIPTION
The "Breakpoints" page of the new MidasInspector were removed.

![image](https://user-images.githubusercontent.com/33934979/116935372-c9a28100-ac55-11eb-85e3-18e2c6fcf7b8.png)

But it is still present in the Pharo inspector

![image](https://user-images.githubusercontent.com/33934979/116935761-59482f80-ac56-11eb-916e-81804c8bfdb3.png)
