### PR TITLE
Add the new tools extension back

### DIFF
--- a/src/BaselineOfMidas/BaselineOfMidas.class.st
+++ b/src/BaselineOfMidas/BaselineOfMidas.class.st
@@ -45,8 +45,7 @@ BaselineOfMidas >> defineGroups: spec [
 		with:
 			#( 'Midas-Core' 'Midas-Visualization' 'Midas-Meta' 'Midas-Tests'
 			   'Midas-Dependency' 'Midas-Famix' 'Midas-Tagging' 'Midas-FamixQueries'
-			   'Midas-FamixQueries-Tests' 'Midas-Telescope' 'Midas-Export' ).
-	spec group: 'newtools' with: #( 'default' 'Midas-NewTools' )
+			   'Midas-FamixQueries-Tests' 'Midas-Telescope' 'Midas-Export' 'Midas-NewTools' ).
 ]
 
 { #category : #baselines }
@@ -102,11 +101,6 @@ BaselineOfMidas >> mooseFinder: spec [
 		project: 'Moose-Finder'
 		copyFrom: 'Moose'
 		with: [ spec loads: 'Moose-Finder' ]
-]
-
-{ #category : #dependencies }
-BaselineOfMidas >> newTools: spec [
-	spec baseline: 'NewTools' with: [ spec repository: 'github://pharo-spec/NewTools:67cc6fa' ]
 ]
 
 { #category : #dependencies }


### PR DESCRIPTION
This PR adds the extension back in the inspectors

Maybe we will change the package and/or their name in the future.
But, at least, they will be present.

It adds navigation, moose properties, fame panel, and tree

![image](https://user-images.githubusercontent.com/6225039/117669889-ade43100-b1a7-11eb-937c-64db63370fc9.png)

The implementation of the tree tab will be to be fixed