### PR TITLE
Removed redefinition of new method in MiNewQueriesBrowser

### DIFF
--- a/src/Midas-NewTools/MiNewQueriesBrowser.class.st
+++ b/src/Midas-NewTools/MiNewQueriesBrowser.class.st
@@ -29,16 +29,6 @@ MiNewQueriesBrowser class >> menuCommandOn: aBuilder [
 		action: [ self runMe ]
 ]
 
-{ #category : #private }
-MiNewQueriesBrowser class >> new [
-
-	"A MooseGroup is necessary to initialize this presenter"
-
-	^ self on: (FQRootQuery new
-			   result: MooseGroup new;
-			   yourself)
-]
-
 { #category : #'instance creation' }
 MiNewQueriesBrowser class >> newModel [
 


### PR DESCRIPTION
In fact the redefinition of `new` method was not needed at all.