### PR TITLE
Moving Inspector tabs definition class

### DIFF
--- a/src/Midas-NewTools/MooseEntity.extension.st
+++ b/src/Midas-NewTools/MooseEntity.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #MooseEntity }
 
 { #category : #'*Midas-NewTools' }
-MooseEntity >> miFameExtension [
-	<inspectorPresentationOrder: 2 title: 'Fame'>
-	^ MiFameExtension on: self
-]
-
-{ #category : #'*Midas-NewTools' }
 MooseEntity >> miNavigationExtension [
 	<inspectorPresentationOrder: 0 title: 'Navigation'>
 	^ MiNavigationBrowser on: self

--- a/src/Midas-NewTools/MooseEntity.extension.st
+++ b/src/Midas-NewTools/MooseEntity.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #MooseEntity }
 
 { #category : #'*Midas-NewTools' }
-MooseEntity >> miNavigationExtension [
-	<inspectorPresentationOrder: 0 title: 'Navigation'>
-	^ MiNavigationBrowser on: self
-]
-
-{ #category : #'*Midas-NewTools' }
 MooseEntity >> miPropertiesExtension [
 	<inspectorPresentationOrder: 1 title: 'Moose Properties'>
 	^ MiPropertyExtension on: self

--- a/src/Midas-NewTools/MooseObject.extension.st
+++ b/src/Midas-NewTools/MooseObject.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #MooseObject }
+
+{ #category : #'*Midas-NewTools' }
+MooseObject >> miFameInspectorExtension [
+
+	<inspectorPresentationOrder: 3 title: 'Fame'>
+	^ MiFameExtension on: self
+]

--- a/src/Midas-NewTools/MooseObject.extension.st
+++ b/src/Midas-NewTools/MooseObject.extension.st
@@ -6,3 +6,10 @@ MooseObject >> miFameInspectorExtension [
 	<inspectorPresentationOrder: 3 title: 'Fame'>
 	^ MiFameExtension on: self
 ]
+
+{ #category : #'*Midas-NewTools' }
+MooseObject >> miNavigationInspectorExtension [
+
+	<inspectorPresentationOrder: 0 title: 'Navigation'>
+	^ MiNavigationBrowser on: self
+]


### PR DESCRIPTION
The inspector tabs were declared in `MooseObjectMoved` in the previous version (Moose Finder). (See `mooseFinderFameDescription:` and `mooseFinderNavigationIn:`).
So the fame and navigation tabs were method to `MooseObject` instead of `MooseEntity`. 