### PR TITLE
Moving moose properties tab and refactors

### DIFF
--- a/src/Midas-NewTools/MooseAbstractGroup.extension.st
+++ b/src/Midas-NewTools/MooseAbstractGroup.extension.st
@@ -1,7 +1,8 @@
 Extension { #name : #MooseAbstractGroup }
 
 { #category : #'*Midas-NewTools' }
-MooseAbstractGroup >> miNavigationExtension [
+MooseAbstractGroup >> miNavigationInspectorExtension [
+
 	<inspectorPresentationOrder: 0 title: 'Navigation'>
 	^ MiAbstractGroupNavigationBrowser on: self
 ]

--- a/src/Midas-NewTools/MooseEntity.extension.st
+++ b/src/Midas-NewTools/MooseEntity.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #MooseEntity }
-
-{ #category : #'*Midas-NewTools' }
-MooseEntity >> miPropertiesExtension [
-
-	<inspectorPresentationOrder: 2 title: 'Moose Properties'>
-	^ MiPropertyExtension on: self
-]

--- a/src/Midas-NewTools/MooseModel.extension.st
+++ b/src/Midas-NewTools/MooseModel.extension.st
@@ -1,7 +1,8 @@
 Extension { #name : #MooseModel }
 
 { #category : #'*Midas-NewTools' }
-MooseModel >> miNavigationExtension [
+MooseModel >> miNavigationInspectorExtension [
+
 	<inspectorPresentationOrder: -100 title: 'Navigation'>
 	^ MiModelNavigationBrowser on: self
 ]

--- a/src/Midas-NewTools/MooseObject.extension.st
+++ b/src/Midas-NewTools/MooseObject.extension.st
@@ -13,3 +13,10 @@ MooseObject >> miNavigationInspectorExtension [
 	<inspectorPresentationOrder: 0 title: 'Navigation'>
 	^ MiNavigationBrowser on: self
 ]
+
+{ #category : #'*Midas-NewTools' }
+MooseObject >> miPropertiesInspectorExtension [
+
+	<inspectorPresentationOrder: 2 title: 'Moose Properties'>
+	^ MiPropertyExtension on: self
+]


### PR DESCRIPTION
- Moose properties method declaration was moved from `MooseEntity` to `MooseObject`.
- Renamed method from `miNavigationExtension` to `miNavigationInspectorExtension`