### PR TITLE
Migrate UI of query numeric configuration presenter to the new queries browser

### DIFF
--- a/src/Midas-NewTools/FQNumericQuery.extension.st
+++ b/src/Midas-NewTools/FQNumericQuery.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #FQNumericQuery }
 { #category : #'*Midas-NewTools' }
 FQNumericQuery >> miPresenterClass [
 
-	^ MiNumericQueryPresenter
+	^ MiNumericInlineQueryPresenter
 ]

--- a/src/Midas-NewTools/MiNumericInlineQueryPresenter.class.st
+++ b/src/Midas-NewTools/MiNumericInlineQueryPresenter.class.st
@@ -1,0 +1,29 @@
+"
+I am a subclass of `MiNumericQueryPresenter`. My only purpose is to re-implement the layout. Because I will be used in the new queries browser and this new browser has a different kind of format fot the ui. It is an inline presentation format.
+"
+Class {
+	#name : #MiNumericInlineQueryPresenter,
+	#superclass : #MiNumericQueryPresenter,
+	#category : #'Midas-NewTools-Queries configuration'
+}
+
+{ #category : #specs }
+MiNumericInlineQueryPresenter class >> layout [
+
+	| padding |
+	padding := 5.
+	^ SpBoxLayout newLeftToRight
+		  add: #propertyDropList withConstraints: [ :cons | 
+			  cons
+				  expand: true;
+				  padding: padding ];
+		  add: #comparatorDropList withConstraints: [ :cons | 
+		  cons
+			  width: 70;
+			  padding: padding ];
+		  add: #valueInputField withConstraints: [ :cons | 
+		  cons
+			  width: 150;
+			  padding: padding ];
+		  yourself
+]

--- a/src/Midas-NewTools/MiStringQueryInlinePresenter.class.st
+++ b/src/Midas-NewTools/MiStringQueryInlinePresenter.class.st
@@ -10,23 +10,20 @@ Class {
 { #category : #specs }
 MiStringQueryInlinePresenter class >> layout [
 
-	| padding wrappedLayout |
+	| padding |
 	padding := 5.
-	wrappedLayout := SpBoxLayout newLeftToRight
-		                 add: #propertyDropList
-		                 expand: false
-		                 fill: false
-		                 padding: padding;
-		                 add: #comparatorDropList
-		                 expand: false
-		                 fill: false
-		                 padding: padding;
-		                 add: #valueInputField
-		                 expand: true
-		                 fill: true
-		                 padding: padding;
-		                 yourself.
-	^ SpBoxLayout newTopToBottom
-		  add: wrappedLayout height: self toolbarHeight;
+	^ SpBoxLayout newLeftToRight
+		  add: #propertyDropList
+		  expand: false
+		  fill: false
+		  padding: padding;
+		  add: #comparatorDropList
+		  expand: false
+		  fill: false
+		  padding: padding;
+		  add: #valueInputField
+		  expand: true
+		  fill: true
+		  padding: padding;
 		  yourself
 ]


### PR DESCRIPTION
New UI:
![image](https://user-images.githubusercontent.com/33934979/118290140-9ec1f380-b4c5-11eb-83a1-96d3ba6505c8.png)

This does not affect the previous queries browser.

![image](https://user-images.githubusercontent.com/33934979/118290270-c5802a00-b4c5-11eb-80ac-abe2103ce099.png)

Also I did a little refactor: I refactored some method of string inline configuration presenter.