### PR TITLE
Migrating boolean query configuration presenter

### DIFF
--- a/src/Midas-NewTools/FQBooleanQuery.extension.st
+++ b/src/Midas-NewTools/FQBooleanQuery.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #FQBooleanQuery }
 { #category : #'*Midas-NewTools' }
 FQBooleanQuery >> miPresenterClass [
 
-	^ MiBooleanQueryPresenter
+	^ MiBooleanInlineQueryPresenter
 ]

--- a/src/Midas-NewTools/FQStringQuery.extension.st
+++ b/src/Midas-NewTools/FQStringQuery.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #FQStringQuery }
 { #category : #'*Midas-NewTools' }
 FQStringQuery >> miPresenterClass [
 
-	^ MiStringQueryInlinePresenter
+	^ MiStringInlineQueryPresenter
 ]

--- a/src/Midas-NewTools/MiBooleanInlineQueryPresenter.class.st
+++ b/src/Midas-NewTools/MiBooleanInlineQueryPresenter.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #MiBooleanInlineQueryPresenter,
+	#superclass : #MiBooleanQueryPresenter,
+	#category : #'Midas-NewTools-Queries configuration'
+}

--- a/src/Midas-NewTools/MiBooleanInlineQueryPresenter.class.st
+++ b/src/Midas-NewTools/MiBooleanInlineQueryPresenter.class.st
@@ -1,5 +1,25 @@
+"
+I am a subclass of `MiBooleanQueryPresenter`. My only purpose is to re-implement the layout. Because I will be used in the new queries browser and this new browser has a different kind of format fot the ui. It is an inline presentation format.
+"
 Class {
 	#name : #MiBooleanInlineQueryPresenter,
 	#superclass : #MiBooleanQueryPresenter,
 	#category : #'Midas-NewTools-Queries configuration'
 }
+
+{ #category : #specs }
+MiBooleanInlineQueryPresenter class >> layout [
+
+	| padding |
+	padding := 5.
+	^ SpBoxLayout newLeftToRight
+		  add: #propertyDropList
+		  expand: false
+		  fill: true
+		  padding: padding;
+		  add: #comparatorDropList
+		  expand: false
+		  fill: false
+		  padding: padding;
+		  yourself
+]

--- a/src/Midas-NewTools/MiNewQueryCreationPresenter.class.st
+++ b/src/Midas-NewTools/MiNewQueryCreationPresenter.class.st
@@ -106,7 +106,7 @@ MiNewQueryCreationPresenter >> initializeLayout [
 	tempLayout := SpBoxLayout newLeftToRight
 		              spacing: 5;
 		              borderWidth: 5;
-		              add: #queryTypesDropListPresenter expand: false;
+		              add: #queryTypesDropListPresenter width: 130;
 		              add: #queryConfigurationPresenter;
 		              addLast: #addButton
 		              withConstraints: buttonConstraints;

--- a/src/Midas-NewTools/MiNumericInlineQueryPresenter.class.st
+++ b/src/Midas-NewTools/MiNumericInlineQueryPresenter.class.st
@@ -13,17 +13,27 @@ MiNumericInlineQueryPresenter class >> layout [
 	| padding |
 	padding := 5.
 	^ SpBoxLayout newLeftToRight
-		  add: #propertyDropList withConstraints: [ :cons | 
-			  cons
-				  expand: true;
-				  padding: padding ];
-		  add: #comparatorDropList withConstraints: [ :cons | 
-		  cons
-			  width: 70;
-			  padding: padding ];
-		  add: #valueInputField withConstraints: [ :cons | 
-		  cons
-			  width: 150;
-			  padding: padding ];
+		  add: #propertyDropList
+		  expand: false
+		  fill: true
+		  padding: padding;
+		  add: #comparatorDropList
+		  expand: false
+		  fill: true
+		  padding: padding;
+		  add: #valueInputField
+		  expand: true
+		  fill: true
+		  padding: padding;
+		  yourself
+]
+
+{ #category : #initialization }
+MiNumericInlineQueryPresenter >> newValueInputField [
+
+	"The only thing that is changed here is the placeholder."
+
+	^ super newValueInputField
+		  placeholder: 'Numeric value';
 		  yourself
 ]

--- a/src/Midas-NewTools/MiStringInlineQueryPresenter.class.st
+++ b/src/Midas-NewTools/MiStringInlineQueryPresenter.class.st
@@ -2,24 +2,24 @@
 I am a subclass of `MiStringQueryPresenter`. My only purpose is to re-implement the layout. Because I will be used in the new queries browser and this new browser has a different kind of format fot the ui.
 "
 Class {
-	#name : #MiStringQueryInlinePresenter,
+	#name : #MiStringInlineQueryPresenter,
 	#superclass : #MiStringQueryPresenter,
 	#category : #'Midas-NewTools-Queries configuration'
 }
 
 { #category : #specs }
-MiStringQueryInlinePresenter class >> layout [
+MiStringInlineQueryPresenter class >> layout [
 
 	| padding |
 	padding := 5.
 	^ SpBoxLayout newLeftToRight
 		  add: #propertyDropList
 		  expand: false
-		  fill: false
+		  fill: true
 		  padding: padding;
 		  add: #comparatorDropList
 		  expand: false
-		  fill: false
+		  fill: true
 		  padding: padding;
 		  add: #valueInputField
 		  expand: true


### PR DESCRIPTION
New UI:
![image](https://user-images.githubusercontent.com/33934979/118295224-21997d00-b4cb-11eb-808d-e804ac0e9e8d.png)

This does not affect the previous queries browser:

![image](https://user-images.githubusercontent.com/33934979/118295288-30802f80-b4cb-11eb-97af-cb30fc9631c9.png)

Also, this PR does some minor refactors: 
- changes the name of the `MiStringQueryInlinePresenter` to `MiStringInlineQueryPresenter`
- adds a fixed size to the type of query dropdown list.
- refactors the layout of `MiNumericInlineQueryPresenter`