### PR TITLE
Changed SpPanedLayout>>position: to SpPanedLayout>>positionOfSlider:

### DIFF
--- a/src/Midas-FamixQueries/MiQueryCreationPresenter.class.st
+++ b/src/Midas-FamixQueries/MiQueryCreationPresenter.class.st
@@ -22,16 +22,16 @@ MiQueryCreationPresenter class >> buildCommandsGroupWith: presenter forRoot: aCm
 
 { #category : #specs }
 MiQueryCreationPresenter class >> defaultSpec [
+
 	^ SpBoxLayout newVertical
-		add: #toolbar height: self toolbarHeight;
-		add: #breadcrumbs height: self toolbarHeight;
-		add:
-			(SpPanedLayout newHorizontal
-				add: self queryConfigurationLayout;
-				position: 65 percent;
-				add: #resultList;
-				yourself);
-		yourself
+		  add: #toolbar height: self toolbarHeight;
+		  add: #breadcrumbs height: self toolbarHeight;
+		  add: (SpPanedLayout newHorizontal
+				   add: self queryConfigurationLayout;
+				   positionOfSlider: 65 percent;
+				   add: #resultList;
+				   yourself);
+		  yourself
 ]
 
 { #category : #specs }


### PR DESCRIPTION
In the CI log, on line 1435 (https://github.com/moosetechnology/Midas/runs/2611104812) says:
```
Testing project...
Running suite "Pharo64-9.0" with 30 tests.
....DeprecationPerformedNotification: Automatic deprecation code rewrite: The method SpPanedLayout>>#position: called from MiQueryCreationPresenter class>>#defaultSpec has been deprecated. Use #positionOfSlider: instead
SubscriptOutOfBounds: 0
```
This PR should fix this.