### PR TITLE
Updated the UI of the remaining configuration presenters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ name: CI
 # events but only for the development branch
 on:
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
+    branches: [development]
 
 jobs:
   test:

--- a/src/Midas-NewTools/FQNavigationQuery.extension.st
+++ b/src/Midas-NewTools/FQNavigationQuery.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #FQNavigationQuery }
 { #category : #'*Midas-NewTools' }
 FQNavigationQuery >> miPresenterClass [
 
-	^ MiNavigationQueryPresenter
+	^ MiNavigationInlineQueryPresenter
 ]

--- a/src/Midas-NewTools/FQTypeQuery.extension.st
+++ b/src/Midas-NewTools/FQTypeQuery.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #FQTypeQuery }
 { #category : #'*Midas-NewTools' }
 FQTypeQuery >> miPresenterClass [
 
-	^ MiTypeQueryPresenter
+	^ MiTypeInlineQueryPresenter
 ]

--- a/src/Midas-NewTools/MiMultiSelectionTable.class.st
+++ b/src/Midas-NewTools/MiMultiSelectionTable.class.st
@@ -96,7 +96,7 @@ MiMultiSelectionTable >> open [
 { #category : #'accessing model' }
 MiMultiSelectionTable >> setModelBeforeInitialization: aModel [
 
-	"The copy message is to avoid having references to another objects."
+	"The `copy` message is to avoid having references to another objects."
 
 	items := aModel asOrderedCollection copy.
 	selectedItems := items asOrderedCollection copy

--- a/src/Midas-NewTools/MiMultiSelectionTable.class.st
+++ b/src/Midas-NewTools/MiMultiSelectionTable.class.st
@@ -1,0 +1,114 @@
+"
+I am a presenter that allows multiselection. I was created because there is no yet implemented in Spec a drop list with checkboxes (for multi-selection).
+For initialize me you have to set my `displayBlock`, `windowName` and `whenWindowClosedBlock` variables.
+
+For example:
+```
+	(MiMultiSelectionTable on: aCollection)
+		displayBlock: #name;
+		windowName: 'Types';
+		whenWindowClosedDo: [ :selectedTypes | 
+			self someMethod: selectedTypes ]
+```
+
+whenWindowClosedDo is very important, because it will determine the action after selecting the desirable items and closing the window.
+"
+Class {
+	#name : #MiMultiSelectionTable,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'table',
+		'items',
+		'selectedItems',
+		'displayBlock',
+		'windowName',
+		'whenWindowClosedBlock'
+	],
+	#category : #'Midas-NewTools-Queries configuration'
+}
+
+{ #category : #actions }
+MiMultiSelectionTable >> deactivationAction: each [
+
+	selectedItems size = 1
+		ifTrue: [ 
+			UIManager default
+				alert: 'You must select at least one item'
+				title: 'Cannot unselect all items' ]
+		ifFalse: [ selectedItems remove: each ].
+	^ self update
+]
+
+{ #category : #'api - initializing' }
+MiMultiSelectionTable >> displayBlock: aBlock [
+
+	displayBlock := aBlock
+]
+
+{ #category : #initialization }
+MiMultiSelectionTable >> initializeLayout [
+
+	self layout: (SpBoxLayout newTopToBottom
+			 add: #table;
+			 yourself)
+]
+
+{ #category : #initialization }
+MiMultiSelectionTable >> initializePresenter [
+
+	self initializeLayout.
+	self initializeTable
+]
+
+{ #category : #initialization }
+MiMultiSelectionTable >> initializeTable [
+
+	table := self newTable.
+	table
+		addColumn: ((SpCheckBoxTableColumn
+				  title: ''
+				  evaluated: [ :each | selectedItems includes: each ])
+				 onActivation: [ :each | selectedItems add: each ];
+				 onDeactivation: [ :each | self deactivationAction: each ];
+				 width: 20;
+				 yourself);
+		addColumn: (SpStringTableColumn
+				 title: 'Name'
+				 evaluated: [ :each | displayBlock value: each ]);
+		items: items;
+		beResizable
+]
+
+{ #category : #initialization }
+MiMultiSelectionTable >> initializeWindow: aWindowPresenter [
+
+	aWindowPresenter
+		title: windowName;
+		whenClosedDo: [ whenWindowClosedBlock value: selectedItems ]
+]
+
+{ #category : #api }
+MiMultiSelectionTable >> open [
+
+	^ self openModalWithSpec
+]
+
+{ #category : #'accessing model' }
+MiMultiSelectionTable >> setModelBeforeInitialization: aModel [
+
+	"The copy message is to avoid having references to another objects."
+
+	items := aModel asOrderedCollection copy.
+	selectedItems := items asOrderedCollection copy
+]
+
+{ #category : #'api - initializing' }
+MiMultiSelectionTable >> whenWindowClosedDo: aFullBlockClosure [
+
+	whenWindowClosedBlock := aFullBlockClosure
+]
+
+{ #category : #'api - initializing' }
+MiMultiSelectionTable >> windowName: aString [ 
+	windowName := aString
+]

--- a/src/Midas-NewTools/MiNavigationInlineQueryPresenter.class.st
+++ b/src/Midas-NewTools/MiNavigationInlineQueryPresenter.class.st
@@ -1,0 +1,103 @@
+Class {
+	#name : #MiNavigationInlineQueryPresenter,
+	#superclass : #MiNavigationQueryPresenter,
+	#instVars : [
+		'directionDropList',
+		'associationsTable',
+		'associationsButton'
+	],
+	#category : #'Midas-NewTools-Queries configuration'
+}
+
+{ #category : #layout }
+MiNavigationInlineQueryPresenter >> buildLayout [
+
+	| padding |
+	padding := 5.
+	self layout: (SpBoxLayout newLeftToRight
+			 add: #directionDropList
+			 expand: false
+			 fill: true
+			 padding: padding;
+			 add: #associationsButton withConstraints: [ :constraints | 
+				 constraints
+					 width: 150;
+					 padding: padding ] yourself)
+]
+
+{ #category : #initialization }
+MiNavigationInlineQueryPresenter >> initializeAssociationsCheckBoxes [
+
+	"We override this method because we do not want to build the cheboxes"
+
+	
+]
+
+{ #category : #initialization }
+MiNavigationInlineQueryPresenter >> initializeAssociationsTable [
+
+	associationsTable := self
+		                     instantiate: MiMultiSelectionTable
+		                     on: self query availableAssociations.
+	associationsTable
+		displayBlock: [ :item | item mooseDescription name asString ];
+		windowName: 'Associations';
+		whenWindowClosedDo: [ :selectedAssociations | 
+			self updateQueryWithSelectedAssociations: selectedAssociations ]
+]
+
+{ #category : #initialization }
+MiNavigationInlineQueryPresenter >> initializeButton [
+
+	associationsButton := self query availableAssociations
+		                      ifEmpty: [ self noParameterMessage: 'type' ]
+		                      ifNotEmpty: [ 
+			                      self newButton
+				                      label: 'Select associations';
+				                      icon: (self iconNamed: #checkboxSelected);
+				                      action: [ associationsTable open ];
+				                      yourself ]
+]
+
+{ #category : #initialization }
+MiNavigationInlineQueryPresenter >> initializeDirectionRadioButtons [
+
+	"We override this method because we do not want to build the radio buttons since we use now a drop list."
+
+	
+]
+
+{ #category : #initialization }
+MiNavigationInlineQueryPresenter >> initializeDirectionsDropList [
+
+	directionDropList := self newDropList.
+	directionDropList
+		items: self query class directionStrategies;
+		display: #label;
+		whenSelectedItemChangedDo: [ :selectedDirection | 
+			self query resetAndChangeDirection: selectedDirection.
+			self updateAccordingToDirection.
+			self notifyQueryChanged ]
+]
+
+{ #category : #initialization }
+MiNavigationInlineQueryPresenter >> initializePresenters [
+
+	super initializePresenters.
+	self initializeDirectionsDropList.
+	self initializeAssociationsTable.
+	self initializeButton
+]
+
+{ #category : #actions }
+MiNavigationInlineQueryPresenter >> updateQueryWithSelectedAssociations: selectedAssociations [
+
+	| nonSelectedAssociations |
+	nonSelectedAssociations := self query associations difference:
+		                           selectedAssociations.
+	selectedAssociations do: [ :assoc | self query addAssociation: assoc ].
+	nonSelectedAssociations do: [ :assoc | 
+		self query removeAssociation: assoc ].
+	self update.
+	^ self notifyQueryChanged
+]

--- a/src/Midas-NewTools/MiScopeInlineQueryPresenter.class.st
+++ b/src/Midas-NewTools/MiScopeInlineQueryPresenter.class.st
@@ -43,3 +43,9 @@ MiScopeInlineQueryPresenter >> initializePresenters [
 	super initializePresenters.
 	self initializeDirectionsDropList
 ]
+
+{ #category : #initialization }
+MiScopeInlineQueryPresenter >> intializeDirectionRadioButtons [
+
+	"We override this method because we do not want to build the radio buttons since we use now a drop list."
+]

--- a/src/Midas-NewTools/MiTypeInlineQueryPresenter.class.st
+++ b/src/Midas-NewTools/MiTypeInlineQueryPresenter.class.st
@@ -53,7 +53,9 @@ MiTypeInlineQueryPresenter >> initializeTypeCheckBoxes [
 { #category : #initialization }
 MiTypeInlineQueryPresenter >> initializeTypesTable [
 
-	typesTable := MiMultiSelectionTable on: self query availableTypes.
+	typesTable := self
+		              instantiate: MiMultiSelectionTable
+		              on: self query availableTypes.
 	typesTable
 		displayBlock: [ :item | self labelFor: item ];
 		windowName: 'Types';

--- a/src/Midas-NewTools/MiTypeInlineQueryPresenter.class.st
+++ b/src/Midas-NewTools/MiTypeInlineQueryPresenter.class.st
@@ -1,0 +1,73 @@
+Class {
+	#name : #MiTypeInlineQueryPresenter,
+	#superclass : #MiTypeQueryPresenter,
+	#instVars : [
+		'typesTable',
+		'typesButton'
+	],
+	#category : #'Midas-NewTools-Queries configuration'
+}
+
+{ #category : #layout }
+MiTypeInlineQueryPresenter >> buildLayout [
+
+	| padding |
+	padding := 5.
+	self layout: (SpBoxLayout newLeftToRight
+			 add: #typesButton
+			 expand: false
+			 fill: true
+			 padding: padding;
+			 yourself)
+]
+
+{ #category : #initialization }
+MiTypeInlineQueryPresenter >> initializeButton [
+
+	typesButton := self query availableTypes
+		               ifEmpty: [ self noParameterMessage: 'type' ]
+		               ifNotEmpty: [ 
+			               self newButton
+				               label: 'Select types';
+				               icon: (self iconNamed: #checkboxSelected);
+				               action: [ typesTable open ];
+				               yourself ]
+]
+
+{ #category : #initialization }
+MiTypeInlineQueryPresenter >> initializePresenters [
+
+	super initializePresenters.
+	self initializeTypesTable.
+	self initializeButton
+]
+
+{ #category : #initialization }
+MiTypeInlineQueryPresenter >> initializeTypeCheckBoxes [
+
+	"We do not want to build the types checkboxes"
+
+	
+]
+
+{ #category : #initialization }
+MiTypeInlineQueryPresenter >> initializeTypesTable [
+
+	typesTable := MiMultiSelectionTable on: self query availableTypes.
+	typesTable
+		displayBlock: [ :item | self labelFor: item ];
+		windowName: 'Types';
+		whenWindowClosedDo: [ :selectedTypes | 
+			self updateQueryWithSelectedTypes: selectedTypes ]
+]
+
+{ #category : #actions }
+MiTypeInlineQueryPresenter >> updateQueryWithSelectedTypes: selectedTypes [
+
+	| nonSelectedTypes |
+	nonSelectedTypes := self query types difference: selectedTypes.
+	selectedTypes do: [ :type | self query addType: type ].
+	nonSelectedTypes do: [ :type | self query removeType: type ].
+	self update.
+	^ self notifyQueryChanged
+]


### PR DESCRIPTION
Now all the configuration presenters's UI have been adapted to the new queries browser.
![image](https://user-images.githubusercontent.com/33934979/118726947-8af9f280-b821-11eb-9c23-57e26b4c3969.png)

And now a table is opened for allowing multi-selection
![image](https://user-images.githubusercontent.com/33934979/118726996-9e0cc280-b821-11eb-8851-a920e60609ee.png)

This works just like the old browser. Navigation and Type queries were updated.