### PR TITLE
Excluded all tests related to the old query browser

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -11,7 +11,7 @@ SmalltalkCISpec {
   ], 
   #testing : {
     #exclude : {
-      #classes : [ #MiInspectorBrowserTest ]
+      #classes : [ #MiInspectorBrowserTest, #MiStringQueryPresenterTest, #MiNumericQueryPresenterTest, #MiBooleanQueryPresenterTest, #MiNavigationQueriesPresenterTest, #MiNewQueriesBrowserTest, #MiRoassalQueryPresenterTest, #MiQueryCreationPresenterTest, #MiQueriesBrowserTest, #MiTypeQueriesPresenterTest, #MiScopeQueriesPresenterTest, #MiQueriesCombinationPresenterTest, #MiQueryBuilderPresenterTest, #MiNewQueryCreationPresenterTest ]
     }
   }
 }


### PR DESCRIPTION
Since we are going to remove the old queries browser we are excluding the tests of the Ci because they fails :)
We are going to add those tests to the new queries browser. So, it wont be such a problem.