### PR TITLE
changed name of FQNaryQuery to FQNAryQuery

### DIFF
--- a/src/Midas-FamixQueries/MiQueriesCombinationPresenter.class.st
+++ b/src/Midas-FamixQueries/MiQueriesCombinationPresenter.class.st
@@ -108,7 +108,7 @@ MiQueriesCombinationPresenter >> initialize [
 { #category : #initialization }
 MiQueriesCombinationPresenter >> initializeDropList [
 	combinationsDroplist := self newDropList
-		items: FQNaryQuery availableCombinations;
+		items: FQNAryQuery availableCombinations;
 		display: [ :queryClass | queryClass label ];
 		whenSelectedItemChangedDo: [ :queryClass | self updateForQueryClass: queryClass ]
 ]

--- a/src/Midas-NewTools/FQNaryQuery.extension.st
+++ b/src/Midas-NewTools/FQNaryQuery.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #FQNaryQuery }
+Extension { #name : #FQNAryQuery }
 
 { #category : #'*Midas-NewTools' }
-FQNaryQuery class >> isNAryQuery [
+FQNAryQuery class >> isNAryQuery [
 
 	^ true
 ]
 
 { #category : #'*Midas-NewTools' }
-FQNaryQuery class >> miPresenterClass [
+FQNAryQuery class >> miPresenterClass [
 
 	^ MiNAryQueryPresenter
 ]

--- a/src/Midas-NewTools/MiNAryQueryPresenter.class.st
+++ b/src/Midas-NewTools/MiNAryQueryPresenter.class.st
@@ -53,7 +53,7 @@ MiNAryQueryPresenter >> initializeButtons [
 	removeSubqueryFromLayoutButton
 		icon: (self iconNamed: #smallDelete);
 		action: [ self removeSubqueryFromLayout ].
-	"The remove button must be enabled only when there is more than 2 subqueries drop lists."
+	"The remove button must be enabled only when there is more than 2 subqueries in the drop lists."
 	removeSubqueryFromLayoutButton disable
 ]
 

--- a/src/Midas-NewTools/MiQueryBuilderPresenter.class.st
+++ b/src/Midas-NewTools/MiQueryBuilderPresenter.class.st
@@ -50,7 +50,7 @@ MiQueryBuilderPresenter >> availableQueryTypes [
 		queryTypes := queryTypes , FQComplementQuery asOrderedCollection ].
 	"There must be at least two queries to create an n-ary query."
 	presenters size > 1 ifTrue: [ 
-		queryTypes := queryTypes , FQNaryQuery subclasses ].
+		queryTypes := queryTypes , FQNAryQuery subclasses ].
 	^ queryTypes
 ]
 


### PR DESCRIPTION
The name of FQNaryQuery has been changed to FQNAryQuery in the FamixQueries repo. This PR changes the reference of the old class with the new class.