### PR TITLE
Move #mooseInterestingEntity to Midas-New-Tools.

### DIFF
--- a/src/Midas-NewTools-Tests/MiNewToolsExtenstionsTest.class.st
+++ b/src/Midas-NewTools-Tests/MiNewToolsExtenstionsTest.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #MiNewToolsExtenstionsTest,
+	#superclass : #TestCase,
+	#category : #'Midas-NewTools-Tests-Queries Browser'
+}
+
+{ #category : #tests }
+MiNewToolsExtenstionsTest >> testModelMooseInterestingEntity [
+
+	| model storage state |
+	model := MooseModel new.
+	state := model.
+	storage := model entityStorage.
+
+	model mooseInterestingEntity.
+
+	self assert: model identicalTo: state.
+	self assert: model entityStorage identicalTo: storage
+]

--- a/src/Midas-NewTools/Collection.extension.st
+++ b/src/Midas-NewTools/Collection.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #Collection }
+
+{ #category : #'*Midas-NewTools' }
+Collection >> mooseInterestingEntity [
+
+	"Method used in UI. 
+		- For a group with one element, returns this element
+		- For a group, returns a specialized group
+		- For a model, returns the entity storage optimized for runtime."
+
+	^ self asMooseGroup mooseInterestingEntity
+]

--- a/src/Midas-NewTools/MooseGroup.extension.st
+++ b/src/Midas-NewTools/MooseGroup.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #MooseGroup }
+
+{ #category : #'*Midas-NewTools' }
+MooseGroup >> mooseInterestingEntity [
+
+	"Method used in UI. 
+		- For a group with one element, returns this element
+		- For a group, returns a specialized group
+		- For a model, returns the entity storage optimized for runtime."
+
+	^ self size = 1
+		  ifTrue: [ self first mooseInterestingEntity ]
+		  ifFalse: [ self specialize ]
+]

--- a/src/Midas-NewTools/MooseModel.extension.st
+++ b/src/Midas-NewTools/MooseModel.extension.st
@@ -6,3 +6,17 @@ MooseModel >> miNavigationInspectorExtension [
 	<inspectorPresentationOrder: -100 title: 'Navigation'>
 	^ MiModelNavigationBrowser on: self
 ]
+
+{ #category : #'*Midas-NewTools' }
+MooseModel >> mooseInterestingEntity [
+
+	"Method used in UI. 
+		- For a group with one element, returns this element
+		- For a group, returns a specialized group
+		- For a model, returns the entity storage optimized for runtime."
+
+	self flag:
+		'The entity storage should not be changed here, but in the loader or somewhere else'.
+	self entityStorage forRuntime.
+	^ self
+]

--- a/src/Midas-NewTools/Object.extension.st
+++ b/src/Midas-NewTools/Object.extension.st
@@ -10,3 +10,14 @@ Object >> isNAryQuery [
 
 	^ false
 ]
+
+{ #category : #'*Midas-NewTools' }
+Object >> mooseInterestingEntity [
+
+	"Method used in UI. 
+		- For a group with one element, returns this element
+		- For a group, returns a specialized group
+		- For a model, returns the entity storage optimized for runtime."
+
+	^ self
+]


### PR DESCRIPTION
This method is used by UI only. It will be removed from the deprecatd package Moose-Finder in Moose.
The corresponding test is also moved.