### PR TITLE
Fix export of a model

### DIFF
--- a/src/MooseIDE-Core/MiModelExportCommand.class.st
+++ b/src/MooseIDE-Core/MiModelExportCommand.class.st
@@ -34,14 +34,11 @@ MiModelExportCommand >> execute [
 
 { #category : #executing }
 MiModelExportCommand >> exportModel: aModel [
+
 	| fileReference |
-	fileReference := UITheme builder
-		chooseForSaveFileReference: 'Choose location'
-		extensions: self fileExtension
-		path: aModel name.
-	fileReference
-		ifNotNil: [ fileReference
-				writeStreamDo: [ :stream | 
+	fileReference := UITheme builder chooseForSaveFileReference: 'Choose location' extensions: self fileExtension path: nil.
+	fileReference ifNotNil: [
+			fileReference writeStreamDo: [ :stream |
 					self exportModel: aModel toStream: stream.
 					Notification signal: 'Save successful!' ] ]
 ]


### PR DESCRIPTION
MooseIDE export was using the file dialog in a wrong way that could break the export of a model depending on the name of the Moose Model. I'm fixing this