### PR TITLE
adding an alert pointing to transcript if parsing errors were encount…

### DIFF
--- a/src/MooseIDE-Meta/MiImportModelFromFileDialog.class.st
+++ b/src/MooseIDE-Meta/MiImportModelFromFileDialog.class.st
@@ -297,7 +297,7 @@ MiImportModelFromFileDialog >> openEntitiesChoice [
 { #category : 'action' }
 MiImportModelFromFileDialog >> privateImportModel [
 
-	| model importer |
+	| model importer countedParsingErrors |
 	importer := self importerForFile.
 
 	model := mooseModelDroplist selectedItem new.
@@ -308,6 +308,10 @@ MiImportModelFromFileDialog >> privateImportModel [
 		runFilteredBy: importingContext.
 
 	model name: (modelNameInput text ifEmpty: [ 'MooseModel' ]).
+	countedParsingErrors := model entities count: [ :entity | (entity propertyNamed: #parsingError ifAbsent: [ nil ]) isNotNil ].
+	countedParsingErrors > 0 ifTrue: [ 
+		SpInformDialog new title: 'Importing Errors'; label: ('There were ' , countedParsingErrors asString, ' errors during the import, please look at the Transcript for more information (press Fetch if the Transcript is empty).'); openDialog.
+		 ]. 
 
 	^ model
 ]


### PR DESCRIPTION
If there are any errors present during the model importing, dispays the dialog with their count and invite the user to look for them in the Transcript