### PR TITLE
RoassalPresenter updated for Toplo

### DIFF
--- a/src/MooseIDE-Visualization/MiAbstractVisualization.class.st
+++ b/src/MooseIDE-Visualization/MiAbstractVisualization.class.st
@@ -88,10 +88,11 @@ MiAbstractVisualization >> noHighlightColorFor: anEntity [
 { #category : 'running' }
 MiAbstractVisualization >> run [
 
-	self canvas clear.
+	"self canvas clear.
 	self clearLegend.
 	self canvas controllerInteraction: nil.
-	self script value: self canvas
+	self script value: self canvas"
+	self refresh
 ]
 
 { #category : 'highlighting' }


### PR DESCRIPTION
I'm trying to have Toplo working for Moose Browser.
I performed this PR https://github.com/pharo-graphics/Spec-Toplo/pull/36 that will enable the usage of `SpRoassalPresenter` in Toplo.

Everything is not perfect _yet_. However, we can start having Moose Visualisation working.

It requires small changes introduced in `MiAbstractVisualization` to perform a visualization refresh, instead of modying it manually.

I believe the original is made for optimization purpose?

To experiment today with Toplo.

```st
[Metacello new
    baseline: 'Roassal';
    repository: 'github://pharo-graphics/Roassal';
    load: 'Full' ] on: MCMergeOrLoadWarning do: [:warning | warning load ].

[Metacello new
    baseline: 'SpecToplo';
    repository: 'github://badetitou/Spec-Toplo:34-Adapter-for-Roassal';
    load: 'Full' ] on: MCMergeOrLoadWarning do: [:warning | warning load ].

MiApplication current useBackend: #Toplo.
```

Then you can open the SystemComplexity (for instance - after propagating into it entities).
You might need to comment code about shortcut of stuff like this. The purpose is to test Roassal Toplo Adapter

It allows to get such visualization
<img width="1740" height="565" alt="image" src="https://github.com/user-attachments/assets/1d36d553-4cbb-479c-8208-d5a4f8da41e5" />
