### PR TITLE
Improve save and load settings UX in MiSettingsPresenter

### DIFF
--- a/src/MooseIDE-Core/MiSettingsPresenter.class.st
+++ b/src/MooseIDE-Core/MiSettingsPresenter.class.st
@@ -99,9 +99,11 @@ MiSettingsPresenter >> saveSettings [
 		                 extensions: { 'ston' }
 		                 path: ('./pharo-local/' , self defaultSettingsFileName) asFileReference.
 
-	fileReference ifNotNil: [
-			fileReference writeStreamDo: [ :str | STON put: configuration onStream: str ].
-			self inform: 'Settings saved to: ' , fileReference pathString ]
+	[
+		fileReference ifNotNil: [
+				fileReference writeStreamDo: [ :str | STON put: configuration onStream: str ].
+				self inform: 'Settings saved to: ' , fileReference pathString ] ] onErrorDo: [ :err |
+		self inform: 'Error while saving settings: ' , err messageText ]
 ]
 
 { #category : 'accessing - model' }


### PR DESCRIPTION
- Mooved save and load buttons to the toolbar
- open a file browser when saving and loading
- renamed settings file to the corresponding tool
- save settings in ston format 