### PR TITLE
fixed a link to moose documentation

### DIFF
--- a/src/MooseIDE-WelcomeBrowser/MooseIDEWelcomeBrowser.class.st
+++ b/src/MooseIDE-WelcomeBrowser/MooseIDEWelcomeBrowser.class.st
@@ -164,7 +164,7 @@ It allows to represent software system in a model, to query, manipulate, transfo
 
 Moose is based on Pharo and it''s open source under BSD/MIT.
 
-For more information, please visit online documentation: [modularmoose.org](https://modularmoose.org/moose-wiki/).
+For more information, please visit online documentation: [modularmoose.org](https://modularmoose.org/).
 
 Version {3}. Commit: [{4}](https://github.com/moosetechnology/Moose/commit/{5})'
 		  format: {


### PR DESCRIPTION
fix: fixed a broken link to Moose documentation

fix #1557 