### PR TITLE
Repair debugger icons

### DIFF
--- a/src/MooseIDE-Core/MiIconProvider.class.st
+++ b/src/MooseIDE-Core/MiIconProvider.class.st
@@ -144,7 +144,7 @@ MiIconProvider >> iconNamed: aName [
 	^ MooseIcons icons
 		  at: aName
 		  ifAbsent: [
-		  Smalltalk ui icons iconNamed: aName ifNone: [ self noIcon ] ]
+			StPharoDefaultIconProvider new iconNamed: aName ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Delegates icon's research to `StPharoDefaultIconProvider` when an icon is not found in the `MooseIcons`.

Indeed icons were not display when opening a debugger from a MiApplication, this PR fixes it.