### PR TITLE
Updating Moose query browser display

### DIFF
--- a/src/MooseIDE-QueriesBrowser-Tests/MiNavigationQueryPresenterTest.class.st
+++ b/src/MooseIDE-QueriesBrowser-Tests/MiNavigationQueryPresenterTest.class.st
@@ -100,6 +100,39 @@ MiNavigationQueryPresenterTest >> testQueryValidity [
 ]
 
 { #category : 'tests' }
+MiNavigationQueryPresenterTest >> testSelectedAssociationsLabel [
+
+	presenter query beDefaultForParent.
+
+	(presenter presenterAt: #associationsList) activateItem:
+		presenter query availableAssociations first.
+	(presenter presenterAt: #associationsList) activateItem:
+		presenter query availableAssociations second.
+
+
+	self
+		assert: presenter selectedAssociationsLabel label
+		equals: 'Inheritance, Access'
+]
+
+{ #category : 'tests' }
+MiNavigationQueryPresenterTest >> testUpdateDirectionWithSelectedAssociations [
+
+	presenter query beDefaultForParent.
+
+	(presenter presenterAt: #associationsList) activateItem:
+		presenter query availableAssociations first.
+
+	self
+		assert: presenter selectedAssociationsLabel label
+		equals: 'Inheritance'.
+
+	presenter updateDirection: FQLocalIncomingNavigation.
+
+	self assert: presenter selectedAssociationsLabel label equals: ''
+]
+
+{ #category : 'tests' }
 MiNavigationQueryPresenterTest >> testUpdateQueryWithSelectedAssociations [
 
 	| associationsRemoved |

--- a/src/MooseIDE-QueriesBrowser-Tests/MiNavigationQueryPresenterTest.class.st
+++ b/src/MooseIDE-QueriesBrowser-Tests/MiNavigationQueryPresenterTest.class.st
@@ -102,17 +102,22 @@ MiNavigationQueryPresenterTest >> testQueryValidity [
 { #category : 'tests' }
 MiNavigationQueryPresenterTest >> testSelectedAssociationsLabel [
 
+	| item |
 	presenter query beDefaultForParent.
+	item := presenter query availableAssociations select: [ :i |
+		        i name = 'FamixStInheritance' ].
+	(presenter presenterAt: #associationsList) activateItem: item first.
+	item := presenter query availableAssociations select: [ :i |
+		        i name = 'FamixStAccess' ].
 
-	(presenter presenterAt: #associationsList) activateItem:
-		presenter query availableAssociations first.
-	(presenter presenterAt: #associationsList) activateItem:
-		presenter query availableAssociations second.
+	(presenter presenterAt: #associationsList) activateItem: item first.
+	item := presenter query availableAssociations select: [ :i |
+		        i name = 'FamixStInvocation' ].
 
-
+	(presenter presenterAt: #associationsList) activateItem: item first.
 	self
 		assert: presenter selectedAssociationsLabel label
-		equals: 'Inheritance, Access'
+		equals: 'Invocation, Inheritance, Access'
 ]
 
 { #category : 'tests' }
@@ -123,9 +128,7 @@ MiNavigationQueryPresenterTest >> testUpdateDirectionWithSelectedAssociations [
 	(presenter presenterAt: #associationsList) activateItem:
 		presenter query availableAssociations first.
 
-	self
-		assert: presenter selectedAssociationsLabel label
-		equals: 'Inheritance'.
+	self assert: presenter selectedAssociationsLabel label isNotEmpty.
 
 	presenter updateDirection: FQLocalIncomingNavigation.
 

--- a/src/MooseIDE-QueriesBrowser/MiNavigationQueryPresenter.class.st
+++ b/src/MooseIDE-QueriesBrowser/MiNavigationQueryPresenter.class.st
@@ -152,26 +152,25 @@ MiNavigationQueryPresenter >> updateDirection: selectedDirection [
 	self initializeAssociationsList.
 	self initializeAssociationsButton.
 	self initializeLayout.
-
+	self updateLabel.
 	self notifyQueryChanged
 ]
 
 { #category : 'actions' }
 MiNavigationQueryPresenter >> updateLabel [
-	
+
 	| selectedAssociationsString names reducedNames |
 	names := associationsList selectedItems collect: [ :each |
-		each mooseDescription name asString ].
+		         each mooseDescription name asString ].
 	reducedNames := names size > 2
-	ifTrue: [
-		names collect: [ :each |
-			LbCContractor new
-				usingPriorities;
-				removeVowels;
-				ellipsisUpTo: 8;
-				reduce: each ] ]
-	ifFalse: [ names ].
-	selectedAssociationsString := reducedNames joinUsing: ', '.
+		                ifTrue: [
+				                names collect: [ :each |
+						                LbCContractor new
+							                usingPriorities;
+							                ellipsisUpTo: 8;
+							                reduce: each ] ]
+		                ifFalse: [ names ].
+	selectedAssociationsString := names joinUsing: ', '.
 	selectedAssociationsLabel label: selectedAssociationsString
 ]
 

--- a/src/MooseIDE-QueriesBrowser/MiNavigationQueryPresenter.class.st
+++ b/src/MooseIDE-QueriesBrowser/MiNavigationQueryPresenter.class.st
@@ -134,6 +134,12 @@ MiNavigationQueryPresenter >> selectAssociationAction: association [
 	self computeQueryAction: association
 ]
 
+{ #category : 'accessing' }
+MiNavigationQueryPresenter >> selectedAssociationsLabel [
+
+	^ selectedAssociationsLabel
+]
+
 { #category : 'initialization' }
 MiNavigationQueryPresenter >> showAssociationsPopover [
 


### PR DESCRIPTION
- Label was not updated when direction selection was changed
- The associations names were reduced by removing vowels, which was bad
- Created 2 tests for these fixes: Update of the associations label when changing a direction, Check associations label.
Fixes https://github.com/moosetechnology/MooseIDE/issues/1606