### PR TITLE
Print block source code using `sourceNode sourceCode` instead of #asString

### DIFF
--- a/src/Famix-CriticBrowser-Entities/FamixCBContext.class.st
+++ b/src/Famix-CriticBrowser-Entities/FamixCBContext.class.st
@@ -173,7 +173,7 @@ FamixCBContext >> isCBContext [
 { #category : 'printing' }
 FamixCBContext >> printAsBlock [
 
-	^ contextFilter asString
+	^ contextFilter sourceNode sourceCode
 ]
 
 { #category : 'as yet unclassified' }
@@ -234,7 +234,8 @@ FamixCBContext >> stonOn: stonWriter [
 			self class stonAllInstVarNames do: [ :each |
 					(self instVarNamed: each) ifNotNil: [ :value |
 							dictionary at: each asSymbol put: (value isClosure
-									 ifTrue: [ value asString ]
+									 ifTrue: [
+									 value sourceNode sourceCode "The source code of a block. Cf. https://github.com/pharo-project/pharo/issues/19558" ]
 									 ifFalse: [ value ]) ] ] ]
 ]
 

--- a/src/Famix-CriticBrowser-ManualEntities/FamixCBAbstractSeverity.class.st
+++ b/src/Famix-CriticBrowser-ManualEntities/FamixCBAbstractSeverity.class.st
@@ -4,24 +4,26 @@ I am the class defining severity of a condition in MooseCritics.
 I am defined by a level, a unique integer for each of my subclasses, and with a name and an iconName used by the user interface.
 "
 Class {
-	#name : #FamixCBAbstractSeverity,
-	#superclass : #Object,
-	#category : #'Famix-CriticBrowser-ManualEntities-Severities'
+	#name : 'FamixCBAbstractSeverity',
+	#superclass : 'Object',
+	#category : 'Famix-CriticBrowser-ManualEntities-Severities',
+	#package : 'Famix-CriticBrowser-ManualEntities',
+	#tag : 'Severities'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBAbstractSeverity class >> iconName [
 "name of the icon to use for violation printing in the UI (optional)"
 	^ 'blank'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBAbstractSeverity class >> level [
 "an Int (unique to each subclass) to define the level of severity"
 	^ self subclassResponsibility 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBAbstractSeverity class >> title [
 "name of the severity (to print in UI)"
 	^ self subclassResponsibility 

--- a/src/Famix-CriticBrowser-ManualEntities/FamixCBErrorSeverity.class.st
+++ b/src/Famix-CriticBrowser-ManualEntities/FamixCBErrorSeverity.class.st
@@ -2,24 +2,26 @@
 I represent an Error severity in MooseCritics.
 "
 Class {
-	#name : #FamixCBErrorSeverity,
-	#superclass : #FamixCBAbstractSeverity,
-	#category : #'Famix-CriticBrowser-ManualEntities-Severities'
+	#name : 'FamixCBErrorSeverity',
+	#superclass : 'FamixCBAbstractSeverity',
+	#category : 'Famix-CriticBrowser-ManualEntities-Severities',
+	#package : 'Famix-CriticBrowser-ManualEntities',
+	#tag : 'Severities'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBErrorSeverity class >> iconName [
 "name of the icon to use for violation printing in the UI (optional)"
 	^ 'error'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBErrorSeverity class >> level [
 "an Int (unique to each subclass) to define the level of severity"
 	^ 3
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBErrorSeverity class >> title [
 "name of the severity (to print in UI)"
 	^ 'Error'

--- a/src/Famix-CriticBrowser-ManualEntities/FamixCBHintSeverity.class.st
+++ b/src/Famix-CriticBrowser-ManualEntities/FamixCBHintSeverity.class.st
@@ -2,24 +2,26 @@
 I represent an Hint severity in MooseCritics.
 "
 Class {
-	#name : #FamixCBHintSeverity,
-	#superclass : #FamixCBAbstractSeverity,
-	#category : #'Famix-CriticBrowser-ManualEntities-Severities'
+	#name : 'FamixCBHintSeverity',
+	#superclass : 'FamixCBAbstractSeverity',
+	#category : 'Famix-CriticBrowser-ManualEntities-Severities',
+	#package : 'Famix-CriticBrowser-ManualEntities',
+	#tag : 'Severities'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBHintSeverity class >> iconName [
 "name of the icon to use for violation printing in the UI (optional)"
 	^ 'help'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBHintSeverity class >> level [
 "an Int (unique to each subclass) to define the level of severity"
 	^ 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBHintSeverity class >> title [
 "name of the severity (to print in UI)"
 	^ 'Hint'

--- a/src/Famix-CriticBrowser-ManualEntities/FamixCBInformationSeverity.class.st
+++ b/src/Famix-CriticBrowser-ManualEntities/FamixCBInformationSeverity.class.st
@@ -2,24 +2,26 @@
 I represent an Information severity in MooseCritics.
 "
 Class {
-	#name : #FamixCBInformationSeverity,
-	#superclass : #FamixCBAbstractSeverity,
-	#category : #'Famix-CriticBrowser-ManualEntities-Severities'
+	#name : 'FamixCBInformationSeverity',
+	#superclass : 'FamixCBAbstractSeverity',
+	#category : 'Famix-CriticBrowser-ManualEntities-Severities',
+	#package : 'Famix-CriticBrowser-ManualEntities',
+	#tag : 'Severities'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBInformationSeverity class >> iconName [
 "name of the icon to use for violation printing in the UI (optional)"
 	^ 'smallInfo'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBInformationSeverity class >> level [
 "an Int (unique to each subclass) to define the level of severity"
 	^ 4
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBInformationSeverity class >> title [
 "name of the severity (to print in UI)"
 	^ 'Information'

--- a/src/Famix-CriticBrowser-ManualEntities/FamixCBNotAValidQuery.class.st
+++ b/src/Famix-CriticBrowser-ManualEntities/FamixCBNotAValidQuery.class.st
@@ -2,12 +2,14 @@
 I am NotAValidQuery, an error raised when a Rule is instantiated with a query not inheriting from the class MiCriticBrowserAbstractQuery.
 "
 Class {
-	#name : #FamixCBNotAValidQuery,
-	#superclass : #Error,
-	#category : #'Famix-CriticBrowser-ManualEntities-QueryHandler'
+	#name : 'FamixCBNotAValidQuery',
+	#superclass : 'Error',
+	#category : 'Famix-CriticBrowser-ManualEntities-QueryHandler',
+	#package : 'Famix-CriticBrowser-ManualEntities',
+	#tag : 'QueryHandler'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBNotAValidQuery >> messageText [
 
 	^ 'A rule must have a query inheriting from MiCriticBrowserAbstractQuery'

--- a/src/Famix-CriticBrowser-ManualEntities/FamixCBQueryHandler.class.st
+++ b/src/Famix-CriticBrowser-ManualEntities/FamixCBQueryHandler.class.st
@@ -2,15 +2,17 @@
 An abstract class to represent the query side of the model critic browser.
 "
 Class {
-	#name : #FamixCBQueryHandler,
-	#superclass : #Object,
+	#name : 'FamixCBQueryHandler',
+	#superclass : 'Object',
 	#instVars : [
 		'innerQuery'
 	],
-	#category : #'Famix-CriticBrowser-ManualEntities-QueryHandler'
+	#category : 'Famix-CriticBrowser-ManualEntities-QueryHandler',
+	#package : 'Famix-CriticBrowser-ManualEntities',
+	#tag : 'QueryHandler'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 FamixCBQueryHandler class >> on: aQuery [
 
 	^ self new
@@ -18,13 +20,13 @@ FamixCBQueryHandler class >> on: aQuery [
 		  yourself
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FamixCBQueryHandler >> asRuleEditorString [
 
 	^ '[ :entity | entity ]'
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FamixCBQueryHandler >> convertToSTONString [
 
 	"Converts the query to a string used to save the query in STON format.
@@ -34,19 +36,19 @@ FamixCBQueryHandler >> convertToSTONString [
 		  innerQuery storeWithParentsOn: stream ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBQueryHandler >> innerQuery [
 
 	^ innerQuery
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBQueryHandler >> innerQuery: anObject [
 
 	innerQuery := anObject
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 FamixCBQueryHandler >> runOnCollection: aCollection [
 
 	^ innerQuery isUnaryQuery
@@ -54,21 +56,21 @@ FamixCBQueryHandler >> runOnCollection: aCollection [
 		  ifFalse: [ self runOnNAryQuery: aCollection ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 FamixCBQueryHandler >> runOnNAryQuery: aCollection [
 
 	^ innerQuery runOn: (innerQuery subqueries collect: [ :subQuery |
 			   (self class on: subQuery) runOnCollection: aCollection ])
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 FamixCBQueryHandler >> runOnQueryWithParent: aCollection [
 
 	^ innerQuery runOn:
 		  ((self class on: innerQuery parent) runOnCollection: aCollection)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 FamixCBQueryHandler >> runOnUnaryQuery: aCollection [
 
 	^ (innerQuery parent isNil or: [ innerQuery parent isRootQuery ])

--- a/src/Famix-CriticBrowser-ManualEntities/FamixCBRunner.class.st
+++ b/src/Famix-CriticBrowser-ManualEntities/FamixCBRunner.class.st
@@ -6,15 +6,16 @@ I work with classes that have the following API:
 `#condition` should return a FamixCBContidion
 "
 Class {
-	#name : #FamixCBRunner,
-	#superclass : #Object,
+	#name : 'FamixCBRunner',
+	#superclass : 'Object',
 	#instVars : [
 		'rootContext'
 	],
-	#category : #'Famix-CriticBrowser-ManualEntities'
+	#category : 'Famix-CriticBrowser-ManualEntities',
+	#package : 'Famix-CriticBrowser-ManualEntities'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 FamixCBRunner >> addRule: aRule [
 
 	| context |
@@ -23,13 +24,13 @@ FamixCBRunner >> addRule: aRule [
 	rootContext addChild: context
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 FamixCBRunner >> addRules: aCollection [
 
 	aCollection do: [ :rule | self addRule: rule ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 FamixCBRunner >> initialize [
 
 	super initialize.
@@ -38,7 +39,7 @@ FamixCBRunner >> initialize [
 		               yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 FamixCBRunner >> runOn: aMooseGroup [
 
 	rootContext runDownTree: aMooseGroup withCallback: [ ].

--- a/src/Famix-CriticBrowser-ManualEntities/FamixCBScriptQueryHandler.class.st
+++ b/src/Famix-CriticBrowser-ManualEntities/FamixCBScriptQueryHandler.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #FamixCBScriptQueryHandler,
-	#superclass : #FamixCBQueryHandler,
-	#category : #'Famix-CriticBrowser-ManualEntities-QueryHandler'
+	#name : 'FamixCBScriptQueryHandler',
+	#superclass : 'FamixCBQueryHandler',
+	#category : 'Famix-CriticBrowser-ManualEntities-QueryHandler',
+	#package : 'Famix-CriticBrowser-ManualEntities',
+	#tag : 'QueryHandler'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 FamixCBScriptQueryHandler class >> on: aString [
 
 	^ self new
@@ -12,8 +14,8 @@ FamixCBScriptQueryHandler class >> on: aString [
 		  yourself
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 FamixCBScriptQueryHandler >> asRuleEditorString [
 
-	^ innerQuery script asString
+	^ innerQuery script sourceNode sourceCode
 ]

--- a/src/Famix-CriticBrowser-ManualEntities/FamixCBWarningSeverity.class.st
+++ b/src/Famix-CriticBrowser-ManualEntities/FamixCBWarningSeverity.class.st
@@ -2,24 +2,26 @@
 I represent an Warning severity in MooseCritics.
 "
 Class {
-	#name : #FamixCBWarningSeverity,
-	#superclass : #FamixCBAbstractSeverity,
-	#category : #'Famix-CriticBrowser-ManualEntities-Severities'
+	#name : 'FamixCBWarningSeverity',
+	#superclass : 'FamixCBAbstractSeverity',
+	#category : 'Famix-CriticBrowser-ManualEntities-Severities',
+	#package : 'Famix-CriticBrowser-ManualEntities',
+	#tag : 'Severities'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBWarningSeverity class >> iconName [
 "name of the icon to use for violation printing in the UI (optional)"
 	^ 'smallWarning'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBWarningSeverity class >> level [
 "an Int (unique to each subclass) to define the level of severity"
 	^ 2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 FamixCBWarningSeverity class >> title [
 "name of the severity (to print in UI)"
 	^ 'Warning'

--- a/src/Famix-CriticBrowser-ManualEntities/String.extension.st
+++ b/src/Famix-CriticBrowser-ManualEntities/String.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #String }
+Extension { #name : 'String' }
 
-{ #category : #'*Famix-CriticBrowser-ManualEntities' }
+{ #category : '*Famix-CriticBrowser-ManualEntities' }
 String >> asValuable [
 
 	^ (Smalltalk compiler evaluate: self) ifNil: [ self asValidSelector ]

--- a/src/Famix-CriticBrowser-ManualEntities/package.st
+++ b/src/Famix-CriticBrowser-ManualEntities/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Famix-CriticBrowser-ManualEntities' }
+Package { #name : 'Famix-CriticBrowser-ManualEntities' }


### PR DESCRIPTION
Cf. pharo issue 19558.