### PR TITLE
fix: Moose build error

### DIFF
--- a/src/MooseIDE-Meta/MiModelsBrowser.class.st
+++ b/src/MooseIDE-Meta/MiModelsBrowser.class.st
@@ -94,6 +94,13 @@ MiModelsBrowser class >> open [
 	^ MiApplication current openCurrentModelsBrowser
 ]
 
+{ #category : 'as yet unclassified' }
+MiModelsBrowser class >> openForTests: aTestApplication [
+
+	<script>
+	^ aTestApplication openCurrentModelsBrowser
+]
+
 { #category : 'specs' }
 MiModelsBrowser class >> title [
 

--- a/src/MooseIDE-Tests/MiModelsBrowser.extension.st
+++ b/src/MooseIDE-Tests/MiModelsBrowser.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : 'MiModelsBrowser' }
-
-{ #category : '*MooseIDE-Tests' }
-MiModelsBrowser class >> openForTests: aTestApplication [
-
-	<script>
-	^ aTestApplication openCurrentModelsBrowser
-]


### PR DESCRIPTION
fix: moving  #openForTest: as an extension method seems to break Moose build on CI. Reverting this change