### PR TITLE
Optimize tags usage and Distribution map

### DIFF
--- a/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
+++ b/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
@@ -101,6 +101,7 @@ BaselineOfMooseIDE >> definePackages: spec [
 		package: 'MooseIDE-DeadCode-Tests' with: [ spec requires: #( 'MooseIDE-DeadCode' 'MooseIDE-Tests' ) ];		
 		package: 'MooseIDE-DSM' with: [ spec requires: #( 'MooseIDE-Visualization' 'AIHierarchicalClustering' ) ];
 		package: 'MooseIDE-DistributionMap' with: [ spec requires: #( 'MooseIDE-Visualization' 'AIHierarchicalClustering' ) ];
+		package: 'MooseIDE-DistributionMap-Tests' with: [ spec requires: #( 'MooseIDE-DistributionMap' ) ];
 		package: 'MooseIDE-Tests' with: [ spec requires: #( 'MooseIDE-Visualization' ) ];
 		package: 'MooseIDE-AttributedText';
 		package: 'MooseIDE-Famix' with: [ spec requires: #( 'MooseIDE-Visualization' 'MooseIDE-AttributedText' ) ];

--- a/src/MooseIDE-DistributionMap-Tests/MiDistributionMapTagTest.class.st
+++ b/src/MooseIDE-DistributionMap-Tests/MiDistributionMapTagTest.class.st
@@ -1,0 +1,60 @@
+"
+I test tag usage in DistributionMap
+"
+Class {
+	#name : 'MiDistributionMapTagTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'model',
+		'simpleTag',
+		'compositeTag',
+		'newTag',
+		'class1',
+		'class2'
+	],
+	#category : 'MooseIDE-DistributionMap-Tests',
+	#package : 'MooseIDE-DistributionMap-Tests'
+}
+
+{ #category : 'running' }
+MiDistributionMapTagTest >> setUp [
+
+	super setUp.
+	model := FamixTagTestModel new.
+	class1 := FamixTagTestClass named: 'aClass1' model: model.
+	class2 := FamixTagTestClass named: 'aClass2' model: model.
+	simpleTag := model createTagNamed: 'leaf'.
+	compositeTag := (model createTagNamed: 'parent')
+		                addSubTag: simpleTag;
+		                yourself.
+	newTag := model createTagNamed: 'newTag'
+]
+
+{ #category : 'tests' }
+MiDistributionMapTagTest >> testIsApplicableTo [
+
+	simpleTag tagEntity: class1.
+	self assert: (simpleTag isApplicableTo: class1)
+]
+
+{ #category : 'tests' }
+MiDistributionMapTagTest >> testIsApplicableToOtherClass [
+
+	simpleTag tagEntity: class1.
+	self deny: (simpleTag isApplicableTo: class2)
+]
+
+{ #category : 'tests' }
+MiDistributionMapTagTest >> testIsApplicableToOtherModel [
+	
+	| class3 |
+	class3 := FamixTagTestClass named: 'aClass3'.
+	simpleTag tagEntity: class3.
+	self assert: (simpleTag isApplicableTo: class3)
+]
+
+{ #category : 'tests' }
+MiDistributionMapTagTest >> testIsNotApplicableTo [
+
+	self deny: (simpleTag isApplicableTo: class1)
+]

--- a/src/MooseIDE-DistributionMap-Tests/package.st
+++ b/src/MooseIDE-DistributionMap-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'MooseIDE-DistributionMap-Tests' }

--- a/src/MooseIDE-DistributionMap/FamixTag.extension.st
+++ b/src/MooseIDE-DistributionMap/FamixTag.extension.st
@@ -3,5 +3,5 @@ Extension { #name : 'FamixTag' }
 { #category : '*MooseIDE-DistributionMap' }
 FamixTag >> isApplicableTo: anEntity [
 
-	^ self taggedEntities anySatisfy: [ :e | e = anEntity ]
+	^ anEntity tags includes: self
 ]


### PR DESCRIPTION
I discovered that using tag with large distribution map is very inefficient. This PR aims to improve it.

- [x] add tests for extension method `isApplicableTo:`
- [x] Improve execution (https://github.com/moosetechnology/MooseIDE/pull/1653/changes#diff-2fb9b874b45eb4c1cf676af2b676d2a00f94d6f51ce971fca07a497eade79ecbL6)
- [x] perform bench and report here

# Improvment explanation

The previous code:

```smalltalk
isApplicableTo: anEntity

	^ self taggedEntities anySatisfy: [ :e | e = anEntity ]
```

Was
1. iterate over the all model then for each entity
2. Search if it has the tags `self` and return the collection of entities with tag `self`
3. Check if the collection includes `anEntity`

The correction propose to check directly in `anEntity` tag, if the tag `self` is present.

# bench

```smalltalk
"setup bench"
model := FamixTagTestModel new.
helloTag := model createTagNamed: 'hello'.
1 to: 10000 do: [ :idx | 
	|clazz|
	clazz := FamixTagTestClass named: 'aClass1' model: model.
	idx even ifTrue: [ clazz tagWith: helloTag ] 
	].
classes := (model allWithType: FamixTagTestClass).

"bench"

[classes do: [ :class | helloTag isApplicableTo: class ]] bench.

"Before optimization"
"3 iterations in 6 seconds 542 milliseconds. 0.459 per second"

"After optimization"
"1,474 iterations in 5 seconds 2 milliseconds. 294.682 per second"


```

# First test

First test with  time profiler and trying unsafe improvment of `isApplicableTo:` shows this (from 110 761 ms to 5 977 ms)

<img width="1485" height="424" alt="image" src="https://github.com/user-attachments/assets/d95de1bc-62ad-49f4-919b-0ff17a9a7301" />

I'll add tests and investigate more

## Might need further investigation

- I don't achieve to create dynamic Tag and transmit it to the Distribution map